### PR TITLE
Add the miqversions executable to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# miqversions executable built locally for testing
+miqversions


### PR DESCRIPTION
I'm not sure if this is the right way to test changes, but I built the executable locally in my development directory using `go build`

This gave me a dirty git status. I don't want a dirty git status.